### PR TITLE
Update to z-95 expansion pack

### DIFF
--- a/src/assets/sources/galactic-republic.ts
+++ b/src/assets/sources/galactic-republic.ts
@@ -275,7 +275,7 @@ export const t: Source[] = [
     wave: 11,
     released: true,
     contents: {
-      ships: { clonez95headhunter: 1 },
+      ships: { clonez95headhunter: 2 },
       pilots: {
         killer: 1,
         drift: 1,
@@ -289,7 +289,7 @@ export const t: Source[] = [
         reapersquadronscout: 2,
       },
       upgrades: {
-        advancedprotontorpedoes: 2,
+        advprotontorpedoes: 2,
         angleddeflectors: 2,
         enduring: 2,
         firecontrolsystem: 2,


### PR DESCRIPTION
noticed inaccuracies in “collections”

clone z95 expansion comes with 2 ships.
advancedprotontorpedoes does not count toward collection and seems to be defined as advprotontorpedoes