### PR TITLE
Remove config from Mace

### DIFF
--- a/src/assets/pilots/galactic-republic/delta-7-aethersprite.ts
+++ b/src/assets/pilots/galactic-republic/delta-7-aethersprite.ts
@@ -156,7 +156,6 @@ const t: ShipType = {
         'Force Power',
         'Force Power',
         'Astromech',
-        'Configuration',
         'Modification',
       ],
       ffg: 512,


### PR DESCRIPTION
https://forums.atomicmassgames.com/topic/11260-delta-7-mace-missing-a-config-slot-on-the-points-document/