### PR TITLE
Scum Y-wing - Leema Kai (incorrect slots)

### DIFF
--- a/src/assets/pilots/scum-and-villainy/btl-a4-y-wing.ts
+++ b/src/assets/pilots/scum-and-villainy/btl-a4-y-wing.ts
@@ -143,7 +143,6 @@ const t: ShipType = {
       ability:
         "Before you engage, if you are not in any enemy ship's [Front Arc], you may acquire a lock on an enemy ship in your full front arc.",
       slots: [
-        'Talent',
         'Tech',
         'Turret',
         'Torpedo',


### PR DESCRIPTION
Leema Kai (Scum Y-wing) should not have a talent slot.