### PR TITLE
Update tie-reaper.ts - Controlled Ailerons

### DIFF
--- a/src/assets/pilots/galactic-empire/tie-reaper.ts
+++ b/src/assets/pilots/galactic-empire/tie-reaper.ts
@@ -37,7 +37,7 @@ const t: ShipType = {
     { difficulty: 'White', type: 'Jam' },
   ],
   ability: {
-    name: 'Adaptive Ailerons',
+    name: 'Controlled Ailerons',
     text:
       'Before you reveal your dial, if you are not stressed, you may boost.',
   },


### PR DESCRIPTION
Changed chassis ability to "Controlled Ailerons". It was inaccurately labeled "Adaptive".